### PR TITLE
Fix bug that can't initialize data of IndexedDB objectStore by key on MacOS

### DIFF
--- a/js/Main.js
+++ b/js/Main.js
@@ -217,10 +217,11 @@
             var tx = db.transaction("jy", "readwrite");
             var store = tx.objectStore("jy");
             var index = store.index("dataIndex");
-            var getdata = store.get(key);
-            getdata.onsuccess = function() {
-                if (getdata.result) {
-                    callback(getdata.result.data);
+            var openCursor = store.openCursor(key);
+            openCursor.onsuccess = function() {
+                var cursor = openCursor.result;
+                if (cursor) {
+                    callback(cursor.value.data);
                 }
                 else {
                     next();


### PR DESCRIPTION
**Bug:** Can't initialize data of IndexdeDB objectStore by an mon-exist key on MacOS.
API `objectStore.get(key)` return an object (`{key:'string', data: null}`) on MacOS. So that non-exsit key check fails. It will not create new entry but get data with null. Some how it returns `null` on windows, so that null detection works and new entry created.

**Solution:** Use API 'objectStore.openCursor(key)` for non-exsit key check and data read.

Ref: https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/get